### PR TITLE
Add support for toolchain files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable]
+        rust: [
+          # Test with toolchain file override
+          "1.50",
+          "nightly",
+          "beta",
+          "stable",
+        ]
     steps:
       - uses: actions/checkout@v3
+      # Test toolchain file support
+      - name: Write rust-toolchain.toml
+        run: |
+          cat <<EOF >>rust-toolchain.toml
+          [toolchain]
+          channel = "nightly-2020-07-10"
+          components = [ "rustfmt", "rustc-dev" ]
+          targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
+          profile = "minimal"
+          EOF
+        shell: bash
+        if: matrix.rust == '1.50'
+
       - uses: ./
         name: Run actions-rust-lang/setup-rust-toolchain ${{matrix.rust}}
         id: toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2022-07-21
+
+### Added
+
+* Prefer toolchain definitions in `rust-toolchain` or `rust-toolchain.toml` files ([Toolchain File](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)).
+    Other input values are ignored if either file is found.
+
 ## [1.1.0] - 2022-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ jobs:
 ## Inputs
 
 All inputs are optional.
+If a [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) (i.e., `rust-toolchain` or `rust-toolchain.toml`) is found in the root of the repository, it takes precedence.
+All input values are ignored if a toolchain file exists.
 
 | Name         | Description                                                                       | Default |
 | ------------ | --------------------------------------------------------------------------------- | ------- |

--- a/action.yml
+++ b/action.yml
@@ -60,22 +60,29 @@ runs:
       shell: bash
     - name: rustup toolchain install ${{inputs.toolchain}}
       run: |
-        rustup toolchain install ${{inputs.toolchain}}${{steps.flags.outputs.targets}}${{steps.flags.outputs.components}} --profile minimal${{steps.flags.outputs.downgrade}} --no-self-update
-        rustup default ${{inputs.toolchain}}
+        if [[ -f "rust-toolchain" || -f "rust-toolchain.toml" ]]
+        then
+          # Install the toolchain as specified in the file
+          # Might break at some point: https://github.com/rust-lang/rustup/issues/1397
+          rustup show
+        else
+          rustup toolchain install ${{inputs.toolchain}}${{steps.flags.outputs.targets}}${{steps.flags.outputs.components}} --profile minimal${{steps.flags.outputs.downgrade}} --no-self-update
+          rustup default ${{inputs.toolchain}}
+        fi
       shell: bash
 
     - name: Print installed versions
       id: versions
       run: |
-        echo "::set-output name=rustc-version::$(rustc +${{inputs.toolchain}} --version)"
-        rustc +${{inputs.toolchain}} --version --verbose
-        echo "::set-output name=cargo-version::$(cargo +${{inputs.toolchain}} --version)"
-        cargo +${{inputs.toolchain}} --version --verbose
-        echo "::set-output name=rustup-version::$(rustup +${{inputs.toolchain}} --version)"
-        rustup +${{inputs.toolchain}} --version
+        echo "::set-output name=rustc-version::$(rustc --version)"
+        rustc --version --verbose
+        echo "::set-output name=cargo-version::$(cargo --version)"
+        cargo --version --verbose
+        echo "::set-output name=rustup-version::$(rustup --version)"
+        rustup --version
 
-        DATE=$(rustc +${{inputs.toolchain}} --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')
-        HASH=$(rustc +${{inputs.toolchain}} --version --verbose | sed -ne 's/^commit-hash: //p')
+        DATE=$(rustc --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')
+        HASH=$(rustc --version --verbose | sed -ne 's/^commit-hash: //p')
         echo "::set-output name=cachekey::$(echo $DATE$HASH | head -c12)"
       shell: bash
 


### PR DESCRIPTION
A toolchain file in the repository root will always take priority.

Closes #1