### PR TITLE
Add an option to disable configuring Rust cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* An option to disable configuring Rust cache.
+
 ## [1.2.1] - 2022-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All input values are ignored if a toolchain file exists.
 | `toolchain`  | Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`.                    | stable  |
 | `target`     | Additional target support to install e.g. `wasm32-unknown-unknown`                |         |
 | `components` | Comma-separated string of additional components to install e.g. `clippy, rustfmt` |         |
+| `cache`      | Automatically configure Rust cache (using `Swatinem/rust-cache`)                  | true    |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
   components:
     description: "Comma-separated list of components to be additionally installed"
     required: false
+  cache:
+    description: "Automatically configure Rust cache"
+    required: false
+    default: "true"
 
 outputs:
   rustc-version:
@@ -100,4 +104,5 @@ runs:
       shell: bash
 
     - name: "Setup Rust Caching"
+      if: inputs.cache == 'true'
       uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
This adds additional input `cache` that determines if `Swatinem/rust-cache` is configured. Closes #3.