### PR TITLE
Fix adding CARGO_HOME to PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2022-09-15
+
+### Fixed
+
+* Fix setting `$CARGO_HOME` to a valid path, in case rustup is installed from the internet.
+    Thanks to @nahsi for providing the fix.
+
 ## [1.3.1] - 2022-08-14
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
       run: |
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          echo "${CARGO_HOME:-~/.cargo}/bin" >> $GITHUB_PATH
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
         fi
       if: runner.os != 'Windows'
       shell: bash


### PR DESCRIPTION
`~/.cargo/bin` is not a valid entry for $PATH, I think. It is not expanded.

The action works on `ubuntu-latest` where stable rust toolchain already present with rust tools like cargo etc, but it fails on self-hosted runners.