### PR TITLE
Enable sparse registry access using the stable configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           cat <<EOF >>rust-toolchain.toml
           [toolchain]
-          channel = "nightly-2020-07-10"
+          channel = "nightly-2022-09-10"
           components = [ "rustfmt", "rustc-dev" ]
           targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
           profile = "minimal"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
       matrix:
         rust: [
           # Test with toolchain file override
-          "1.50",
+          "1.60",
+          # Test that the sparse registry check works.
+          # 1.66 and 1.67 don't support stable sparse registry.
+          "1.66",
           "nightly",
           "beta",
           "stable",
@@ -33,7 +36,7 @@ jobs:
           profile = "minimal"
           EOF
         shell: bash
-        if: matrix.rust == '1.50'
+        if: matrix.rust == '1.60'
 
       - uses: ./
         name: Run actions-rust-lang/setup-rust-toolchain ${{matrix.rust}}
@@ -48,3 +51,10 @@ jobs:
         run: echo '${{steps.toolchain.outputs.rustup-version}}'
       - run: rustc --version && cargo --version
         shell: bash
+
+      # Test with creating a small project
+      - run: cargo init . --bin --name CI
+      # Add tiny empty crate.
+      # This checks that registry access works.
+      - run: cargo add serde_as
+      - run: cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
 
       # Test with creating a small project
-      - run: cargo init . --bin --name CI
+      - run: cargo init . --bin --name ci
       # Add tiny empty crate.
       # This checks that registry access works.
       - run: cargo add serde_as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Only set environment variables, if they are not set before.
     This allows setting environment variables before using this action and keeping their values.
-    
+* Enable stable sparse registry, except on versions 1.66 and 1.67 where this leads to errors.
+
 ## [1.3.7] - 2023-01-31
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -78,10 +78,6 @@ runs:
         if [[ ! -v CARGO_UNSTABLE_SPARSE_REGISTRY ]]; then
           echo "CARGO_UNSTABLE_SPARSE_REGISTRY=true" >> $GITHUB_ENV
         fi
-        # Enable sparse index after stabilization
-        # This causes warnings on stable 1.67, e.g., when using "cargo add"
-        # https://github.com/rust-lang/cargo/pull/11224
-        # echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
       shell: bash
     - name: "Install Rust Problem Matcher"
       run: echo "::add-matcher::${{ github.action_path }}/rust.json"
@@ -121,6 +117,18 @@ runs:
         DATE=$(rustc --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')
         HASH=$(rustc --version --verbose | sed -ne 's/^commit-hash: //p')
         echo "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Copied from dtolnay/rust-toolchain and adapted
+    # https://github.com/dtolnay/rust-toolchain/blob/25dc93b901a87e864900a8aec6c12e9aa794c0c3/action.yml#L100-L108
+    - name: "Enable cargo sparse registry on stable"
+      run: |
+        # except on 1.66 and 1.67, on which it is unstable
+        if [[ ! -v CARGO_REGISTRIES_CRATES_IO_PROTOCOL ]]; then
+          if echo "${{steps.versions.outputs.rustc-version}}" | not grep -q '^rustc 1\.6[67]\.'; then
+            echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
+          fi
+        fi
       shell: bash
 
     - name: "Setup Rust Caching"


### PR DESCRIPTION
Exclude versions 1.66 and 1.67, which don't support stable sparse registry.