### PR TITLE
Tweak sparse registry version regex and command not found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           [toolchain]
           channel = "nightly-2022-09-10"
           components = [ "rustfmt", "rustc-dev" ]
-          targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
+          targets = [ "wasm32-unknown-unknown", "thumbv7m-none-eabi" ]
           profile = "minimal"
           EOF
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2023-02-15
+
+### Fixed
+
+* Tweak sparse registry version regex to better work with 1.68 nightly versions.
+* Fix command not found issue
+
 ## [1.4.1] - 2023-02-13
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -131,8 +131,10 @@ runs:
     - name: "Enable cargo sparse registry on stable"
       run: |
         # except on 1.66 and 1.67, on which it is unstable
+        # Not all 1.68.0-nightly versions support it either
+        # https://github.com/dtolnay/rust-toolchain/pull/69#discussion_r1107268108
         if [[ ! -v CARGO_REGISTRIES_CRATES_IO_PROTOCOL ]]; then
-          if echo "${{steps.versions.outputs.rustc-version}}" | not grep -q '^rustc 1\.6[67]\.'; then
+          if echo "${{steps.versions.outputs.rustc-version}}" | grep --invert --quiet '^rustc \(1\.6[67]\.\|1\.68\.0-nightly\)'; then
             echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
           fi
         fi


### PR DESCRIPTION
These issues are reported again rust-toolchain from which the code is
inspired.

https://github.com/dtolnay/rust-toolchain/issues/71

https://github.com/dtolnay/rust-toolchain/pull/69#pullrequestreview-1299712112