### PR TITLE
Add new problem matcher that is aware of color codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.4] - 2023-03-18
+
+### Fixed
+
+* Use color aware problem matcher.
+    The problem matcher currently runs against the colored terminal output ([Bug 1](https://github.com/actions/runner/issues/2341), [Bug 2](https://github.com/actions/runner/pull/2430)).
+    The previous matcher was not aware of ANSII color codes and did not work.
+
 ## [1.4.3] - 2023-02-21
 
 ### Fixed

--- a/rust.json
+++ b/rust.json
@@ -16,16 +16,16 @@
             "owner": "clippy",
             "pattern": [
                 {
-                    "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
+                    "regexp": "^(?:\\x1b\\[[\\d;]+m)*(warning|warn|error)(?:\\x1b\\[[\\d;]+m)*(\\[(.*)\\])?(?:\\x1b\\[[\\d;]+m)*:(?:\\x1b\\[[\\d;]+m)* ([^\\x1b]*)(?:\\x1b\\[[\\d;]+m)*$",
                     "severity": 1,
                     "message": 4,
                     "code": 3
                 },
                 {
-                    "regexp": "^([\\s\\->=]*(.*):(\\d*):(\\d*)|.*)$",
-                    "file": 2,
-                    "line": 3,
-                    "column": 4
+                    "regexp": "^(?:\\x1b\\[[\\d;]+m)*\\s*(?:\\x1b\\[[\\d;]+m)*\\s*--> (?:\\x1b\\[[\\d;]+m)*(.*):(\\d*):(\\d*)(?:\\x1b\\[[\\d;]+m)*$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
                 }
             ]
         }


### PR DESCRIPTION
The action runner currently fails to strip color codes from the output.
This means that many matchers currectly do not work.

https://github.com/actions/runner/issues/2341
https://github.com/actions/runner/pull/2430

The new matcher is copied from kaj/rsass which is MIT licensed.

https://github.com/kaj/rsass/blob/3e5d6c0600324fe27b0a0257d3befd4bb345fedb/.github/workflows/rust-problem-matcher.json