### PR TITLE
allow disabling RUSTFLAGS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Before only the items listed in `rust-toolchain` were installed.
     Now all the items from the toolchain file are installed and then all the `target`s and `components` that are provided as action inputs.
     This allows installing extra tools only for CI or simplify testing special targets in CI.
+* Allow skipping the creation of a `RUSTFLAGS` environment variable.
+    Cargos logic for rustflags is complicated, and setting the `RUSTFLAGS` environment variable prevents other ways of working.
+    Provide a new `rustflags` input, which controls the environment variable creation.
+    If the value is set to the empty string, then `RUSTFLAGS` is not created.
+
+    Pre-existing `RUSTFLAGS` variables are never modified by this extension.
 
 ## [1.4.4] - 2023-03-18
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 ### RUSTFLAGS
 
 By default, this action sets the `RUSTFLAGS` environment variable to `-D warnings`.
+However, rustflags sources are mutually exclusive, so setting this environment variable omits any configuration through `target.*.rustflags` or `build.rustflags`.
 
-However, rustflags sources are mutually exclusive, so setting this environment
-variable omits any configuration through `target.*.rustflags` or
-`build.rustflags`.
+* If `RUSTFLAGS` is already set, no modifications of the variable are made and the original value remains.
+* If `RUSTFLAGS` is unset and the `rustflags` input is empty (i.e., the empty string), then it will remain unset.
+    Use this, if you want to prevent the value from being set because you make use of `target.*.rustflags` or `build.rustflags`.
+* Otherwise, the environment variable `RUSTFLAGS` is set to the content of `rustflags`.
 
 To prevent this from happening, set the `rustflags` input to an empty string, which will
 prevent the action from setting `RUSTFLAGS` at all, keeping any existing preferences.

--- a/README.md
+++ b/README.md
@@ -46,12 +46,26 @@ If a [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-tool
 First, all items specified in the toolchain file are installed.
 Afterward, the `components` and `target` specified via inputs are installed in addition to the items from the toolchain file.
 
-| Name         | Description                                                                       | Default |
-| ------------ | --------------------------------------------------------------------------------- | ------- |
-| `toolchain`  | Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`.                    | stable  |
-| `target`     | Additional target support to install e.g. `wasm32-unknown-unknown`                |         |
-| `components` | Comma-separated string of additional components to install e.g. `clippy, rustfmt` |         |
-| `cache`      | Automatically configure Rust cache (using `Swatinem/rust-cache`)                  | true    |
+| Name         | Description                                                                            | Default       |
+| ------------ | -------------------------------------------------------------------------------------- | ------------- |
+| `toolchain`  | Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`.                         | stable        |
+| `target`     | Additional target support to install e.g. `wasm32-unknown-unknown`                     |               |
+| `components` | Comma-separated string of additional components to install e.g. `clippy, rustfmt`      |               |
+| `cache`      | Automatically configure Rust cache (using `Swatinem/rust-cache`)                       | true          |
+| `rustflags`  | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags) | "-D warnings" |
+
+### RUSTFLAGS
+
+By default, this action sets the `RUSTFLAGS` environment variable to `-D warnings`.
+
+However, rustflags sources are mutually exclusive, so setting this environment
+variable omits any configuration through `target.*.rustflags` or
+`build.rustflags`.
+
+To prevent this from happening, set the `rustflags` input to an empty string, which will
+prevent the action from setting `RUSTFLAGS` at all, keeping any existing preferences.
+
+You can read more rustflags, and their load order, in the [Cargo reference].
 
 ## Outputs
 
@@ -68,3 +82,4 @@ License].
 
 [MIT License]: LICENSE
 [Problem Matchers]: https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
+[Cargo reference]: https://doc.rust-lang.org/cargo/reference/config.html?highlight=unknown#buildrustflags

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: "true"
   rustflags:
     description: "set RUSTFLAGS environment variable, set to empty string to avoid overwriting build.rustflags"
-    requred: false
+    required: false
     default: "-D warnings"
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -80,8 +80,8 @@ runs:
         if [[ ! -v RUST_BACKTRACE ]]; then
           echo "RUST_BACKTRACE=short" >> $GITHUB_ENV
         fi
-        if [[ -v "$NEW_RUSTFLAGS" ]]; then
-          echo "RUSTFLAGS="$NEW_RUSTFLAGS" >> $GITHUB_ENV
+        if [[ -v NEW_RUSTFLAGS ]]; then
+          echo "RUSTFLAGS=$NEW_RUSTFLAGS" >> $GITHUB_ENV
         fi
         # Enable faster sparse index on nightly
         # The value is ignored on stable and causes no problems

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Automatically configure Rust cache"
     required: false
     default: "true"
+  rustflags:
+    description: "set RUSTFLAGS environment variable, set to empty string to avoid overwriting build.rustflags"
+    requred: false
+    default: "-D warnings"
 
 outputs:
   rustc-version:
@@ -76,8 +80,8 @@ runs:
         if [[ ! -v RUST_BACKTRACE ]]; then
           echo "RUST_BACKTRACE=short" >> $GITHUB_ENV
         fi
-        if [[ ! -v RUSTFLAGS ]]; then
-          echo "RUSTFLAGS=-D warnings" >> $GITHUB_ENV
+        if [[ -v "$NEW_RUSTFLAGS" ]]; then
+          echo "RUSTFLAGS="$NEW_RUSTFLAGS" >> $GITHUB_ENV
         fi
         # Enable faster sparse index on nightly
         # The value is ignored on stable and causes no problems
@@ -89,6 +93,8 @@ runs:
           echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
         fi
       shell: bash
+      env:
+        NEW_RUSTFLAGS: ${{inputs.rustflags}}
     - name: "Install Rust Problem Matcher"
       run: echo "::add-matcher::${{ github.action_path }}/rust.json"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         if [[ ! -v RUST_BACKTRACE ]]; then
           echo "RUST_BACKTRACE=short" >> $GITHUB_ENV
         fi
-        if [[ -v NEW_RUSTFLAGS ]]; then
+        if [[ "$NEW_RUSTFLAGS" != "" ]]; then
           echo "RUSTFLAGS=$NEW_RUSTFLAGS" >> $GITHUB_ENV
         fi
         # Enable faster sparse index on nightly

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         if [[ ! -v RUST_BACKTRACE ]]; then
           echo "RUST_BACKTRACE=short" >> $GITHUB_ENV
         fi
-        if [[ "$NEW_RUSTFLAGS" != "" ]]; then
+        if [[ ( ! -v RUSTFLAGS ) && $NEW_RUSTFLAGS != "" ]]; then
           echo "RUSTFLAGS=$NEW_RUSTFLAGS" >> $GITHUB_ENV
         fi
         # Enable faster sparse index on nightly


### PR DESCRIPTION
The change in behaviour allows people to use this action, without overwriting their own `rustflags` configurations.