### PR TITLE
Allow overriding the toolchain file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-
 name: CI
 
 on:
@@ -15,7 +14,7 @@ jobs:
       matrix:
         rust: [
           # Test with toolchain file override
-          "1.60",
+          "",
           # Test that the sparse registry check works.
           # 1.66 and 1.67 don't support stable sparse registry.
           "1.66",
@@ -41,10 +40,10 @@ jobs:
           profile = "minimal"
           EOF
         shell: bash
-        if: matrix.rust == '1.60'
+        if: matrix.rust == ''
 
       - uses: ./
-        name: Run actions-rust-lang/setup-rust-toolchain ${{matrix.rust}}
+        name: Run actions-rust-lang/setup-rust-toolchain ${{matrix.rust || 'on toolchain file'}}
         id: toolchain
         with:
           toolchain: ${{matrix.rust}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   install:
-    name: Rust ${{matrix.rust}} ${{matrix.os}}
+    name: Rust ${{matrix.rust || '(toolchain file)'}} ${{matrix.os}}
     runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo test --all-features
- 
+
   # Check formatting with rustfmt
   formatting:
     name: cargo fmt
@@ -42,7 +42,9 @@ jobs:
 ## Inputs
 
 All inputs are optional.
-If a [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) (i.e., `rust-toolchain` or `rust-toolchain.toml`) is found in the root of the repository, its `toolchain` value takes precedence.
+If a [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) (i.e., `rust-toolchain` or `rust-toolchain.toml`) is found in the root of the repository and no `toolchain` value is provided, all items specified in the toolchain file will be installed.
+If a `toolchain` value is provided, the toolchain file will be ignored.
+If no `toolchain` value or toolchain file is present, it will default to `stable`.
 First, all items specified in the toolchain file are installed.
 Afterward, the `components` and `target` specified via inputs are installed in addition to the items from the toolchain file.
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,6 @@ inputs:
   toolchain:
     description: "Rust toolchain specification -- see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification"
     required: false
-    default: "stable"
   target:
     description: "Target triple to install for this toolchain"
     required: false
@@ -107,9 +106,9 @@ runs:
         fi
       if: runner.os != 'Windows'
       shell: bash
-    - name: rustup toolchain install ${{inputs.toolchain}}
+    - name: rustup toolchain install ${{inputs.toolchain || 'stable'}}
       run: |
-        if [[ -f "rust-toolchain" || -f "rust-toolchain.toml" ]]
+        if [[ -z "$toolchain" && ( -f "rust-toolchain" || -f "rust-toolchain.toml" ) ]]
         then
           # Install the toolchain as specified in the file
           # Might break at some point: https://github.com/rust-lang/rustup/issues/1397
@@ -121,10 +120,15 @@ runs:
             rustup target add ${targets//,/ }
           fi
         else
-          rustup toolchain install ${{inputs.toolchain}}${{steps.flags.outputs.targets}}${{steps.flags.outputs.components}} --profile minimal${{steps.flags.outputs.downgrade}} --no-self-update
-          rustup default ${{inputs.toolchain}}
+          if [[ -z "$toolchain" ]]
+          then
+            toolchain=stable
+          fi
+          rustup toolchain install $toolchain${{steps.flags.outputs.targets}}${{steps.flags.outputs.components}} --profile minimal${{steps.flags.outputs.downgrade}} --no-self-update
+          rustup default $toolchain
         fi
       env:
+        toolchain: ${{inputs.toolchain}}
         targets: ${{inputs.target}}
         components: ${{inputs.components}}
       shell: bash


### PR DESCRIPTION
Sometimes we have a toolchain file but want to override it in some specific cases.  For example, in a current project, we want to use nightly `rustfmt`, so our linter step uses nightly Rust even though our main build uses stable Rust.

This PR changes (and documents) the behaviour of the action in the case in which both a toolchain file and a `toolchain` input are present, preferring the `toolchain` input.