### PR TITLE
feature(matcher): allow disabling problem matcher

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Automatically configure Rust cache"
     required: false
     default: "true"
+  matcher:
+    description: "Enable the Rust problem matcher"
+    required: false
+    default: "true"
   rustflags:
     description: "set RUSTFLAGS environment variable, set to empty string to avoid overwriting build.rustflags"
     required: false
@@ -96,6 +100,7 @@ runs:
       env:
         NEW_RUSTFLAGS: ${{inputs.rustflags}}
     - name: "Install Rust Problem Matcher"
+      if: inputs.matcher == 'true'
       run: echo "::add-matcher::${{ github.action_path }}/rust.json"
       shell: bash
 


### PR DESCRIPTION
Allows disabling the problem matcher. This is useful when you have a matrix of rust tasks which end up posting the same issue as many times as you have workflows.