### PR TITLE
feat: adds "cache-on-failure" propagation to Swatinem/rust-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `components`       | Comma-separated string of additional components to install e.g. `clippy, rustfmt`      |               |
 | `cache`            | Automatically configure Rust cache (using `Swatinem/rust-cache`)                       | true          |
 | `cache-workspaces` | Propagates the value to `Swatinem/rust-cache`                                          |               |
+| `cache-on-failure` | Propagates the value to `Swatinem/rust-cache`                                          |               |
 | `matcher`          | Enable problem matcher to surface build messages and formatting issues                 | true          |
 | `rustflags`        | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags) | "-D warnings" |
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
   cache-workspaces:
     description: "Paths to multiple Cargo workspaces and their target directories, separated by newlines."
     required: false
+  cache-on-failure:
+    description: "Also cache on workflow failures"
+    default: "false"
+    required: false
   matcher:
     description: "Enable the Rust problem matcher"
     required: false
@@ -176,3 +180,4 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: ${{inputs.cache-workspaces}}
+        cache-on-failure: ${{inputs.cache-on-failure}}


### PR DESCRIPTION
Pretty self explanatory, adds the propagation of `cache-on-failure` alongside `cache-workspaces`.

This action works really nicely and I didn't want to manually setup cache just because of this, neither did I want to recompile axum every-time my unit tests failed 😆

Backwards compatible, false already is the default value.