### PR TITLE
Add support for adding to cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `cache`            | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                     | true          |
 | `cache-workspaces` | Propagates the value to [`Swatinem/rust-cache`]                                        |               |
 | `cache-on-failure` | Propagates the value to [`Swatinem/rust-cache`]                                        | true          |
+| `key`              | Propagates the value to [`Swatinem/rust-cache`]                                        |               |
 | `matcher`          | Enable problem matcher to surface build messages and formatting issues                 | true          |
 | `rustflags`        | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags) | "-D warnings" |
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `cache`            | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                     | true          |
 | `cache-workspaces` | Propagates the value to [`Swatinem/rust-cache`]                                        |               |
 | `cache-on-failure` | Propagates the value to [`Swatinem/rust-cache`]                                        | true          |
-| `key`              | Propagates the value to [`Swatinem/rust-cache`]                                        |               |
+| `cache-key`        | Propagates the value to [`Swatinem/rust-cache`] as `key`                               |               |
 | `matcher`          | Enable problem matcher to surface build messages and formatting issues                 | true          |
 | `rustflags`        | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags) | "-D warnings" |
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
     description: "Also cache on workflow failures"
     default: "true"
     required: false
+  cache-key:
+    description: "An additional cache key that is added alongside the automatic `job`-based cache key and can be used to further differentiate jobs."
+    required: false
   matcher:
     description: "Enable the Rust problem matcher"
     required: false
@@ -181,3 +184,4 @@ runs:
       with:
         workspaces: ${{inputs.cache-workspaces}}
         cache-on-failure: ${{inputs.cache-on-failure}}
+        key: ${{inputs.cache-key}}


### PR DESCRIPTION
When using this action in multiple matrix jobs in the same workflow, the generated cache key is the same for all of them, because they all get the same job ID. This means that all apart from the first job are unable to save the cache, and subsequent runs might restore the wrong cache.

The `Swatinem/rust-cache` action which we use for caching has a `key` input which it puts in its cache key. (It doesn't override the key, just adds to it.) Providing this as an input here will allow us to generate a unique cache key for each job in the matrix.
