### PR TITLE
fix: add cache-bin input with true as default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `cache-workspaces`  | Propagates the value to [`Swatinem/rust-cache`]                                                                          |               |
 | `cache-on-failure`  | Propagates the value to [`Swatinem/rust-cache`]                                                                          | true          |
 | `cache-key`         | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                 |               |
+| `cache-bin`         | Propagates the value to [`Swatinem/rust-cache`]                                                                          |               |
 | `matcher`           | Enable problem matcher to surface build messages and formatting issues                                                   | true          |
 | `rustflags`         | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                   | "-D warnings" |
 | `override`          | Setup the last installed toolchain as the default via `rustup override`                                                  | true          |

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
   cache-key:
     description: "An additional cache key that is added alongside the automatic `job`-based cache key and can be used to further differentiate jobs."
     required: false
+  cache-bin:
+    description: "Determines whether to cache ${CARGO_HOME}/bin."
+    required: false
+    default: "true"
   matcher:
     description: "Enable the Rust problem matcher"
     required: false
@@ -199,4 +203,5 @@ runs:
         workspaces: ${{inputs.cache-workspaces}}
         cache-directories: ${{inputs.cache-directories}}
         cache-on-failure: ${{inputs.cache-on-failure}}
+        cache-bin: ${{inputs.cache-bin}}
         key: ${{inputs.cache-key}}


### PR DESCRIPTION
## Description
This PR addresses an issue with long-running self-hosted runners where Rust binaries are cleared after the workflow run due to the default behavior of clearing $HOME/.cargo/bin. The change introduces a new input, cache-bin, which allows users to control whether this folder is cached or not.

https://github.com/Swatinem/rust-cache?tab=readme-ov-file#known-issues