### PR TITLE
feat: add shared-cache-key to inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `cache-workspaces`  | Propagates the value to [`Swatinem/rust-cache`]                                                                          |               |
 | `cache-on-failure`  | Propagates the value to [`Swatinem/rust-cache`]                                                                          | true          |
 | `cache-key`         | Propagates the value to [`Swatinem/rust-cache`] as `key`                                                                 |               |
+| `shared-cache-key`  | Propagates the value to [`Swatinem/rust-cache`] as `shared-key`                                                          |               |
 | `matcher`           | Enable problem matcher to surface build messages and formatting issues                                                   | true          |
 | `rustflags`         | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                   | "-D warnings" |
 | `override`          | Setup the last installed toolchain as the default via `rustup override`                                                  | true          |

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   cache-key:
     description: "An additional cache key that is added alongside the automatic `job`-based cache key and can be used to further differentiate jobs."
     required: false
+  shared-cache-key:
+    description: "A cache key that is used instead of the automatic `job`-based key, and is stable over multiple jobs."
+    required: false
   matcher:
     description: "Enable the Rust problem matcher"
     required: false
@@ -200,3 +203,4 @@ runs:
         cache-directories: ${{inputs.cache-directories}}
         cache-on-failure: ${{inputs.cache-on-failure}}
         key: ${{inputs.cache-key}}
+        shared-key: ${{inputs.shared-cache-key}}


### PR DESCRIPTION
I've added a new `shared-cache-key` to inputs because I want to share caches between jobs