### PR TITLE
Support rustup installation for Windows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -130,13 +130,20 @@ runs:
       run: echo "::add-matcher::${{ github.action_path }}/rust.json"
 
     - name: Install rustup, if needed
-      if: runner.os != 'Windows'
       shell: bash
       run: |
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          
+          # Resolve the correct CARGO_HOME path depending on OS
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "${CARGO_HOME:-$USERPROFILE/.cargo}/bin" | sed 's|/|\\|g' >> $GITHUB_PATH
+          else
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
         fi
+      env:
+        RUNNER_OS: "${{ runner.os }}"
 
     - name: rustup toolchain install ${{inputs.toolchain || 'stable'}}
       env:


### PR DESCRIPTION
Fixes #57 
Fixes #45

## Changes

* Runs rustup installation for WIndows as well
* Changes the way the cargo bin dir is added to the `PATH` so that it works on windows as well.

## Running example

* CI: https://github.com/maennchen/gleam/actions/runs/14621306902/job/41021784371
* Action: https://github.com/maennchen/gleam/blob/175397554223d15974fd95cb25229326a92af82e/.github/actions/build-release/action.yml#L40-L44