### PR TITLE
Explicitly specify cache action sourceforge

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -208,7 +208,7 @@ runs:
 
     - name: Setup Rust Caching
       if: inputs.cache == 'true'
-      uses: Swatinem/rust-cache@v2
+      uses: https://github.com/Swatinem/rust-cache@v2
       with:
         workspaces: ${{inputs.cache-workspaces}}
         cache-directories: ${{inputs.cache-directories}}


### PR DESCRIPTION
Fixes this workflow always failing on sourceforges that don't implicitly assume GitHub as the host for workflow actions (i.e. Forgejo). Seems like this syntax is also valid on GitHub, but I haven't tested it myself.