### PR TITLE
feat: install cargo packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `toolchain`         | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`.  The last version is the default. | stable        |
 | `target`            | Additional target support to install e.g. `wasm32-unknown-unknown`                                                       |               |
 | `components`        | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                        |               |
+| `cargo-packages`    | Comma-separated string of Cargo packages to install e.g. `cargo-edit, cargo-tarpaulin`                                   |               |
 | `cache`             | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                       | true          |
 | `cache-directories` | Propagates the value to [`Swatinem/rust-cache`]                                                                          |               |
 | `cache-workspaces`  | Propagates the value to [`Swatinem/rust-cache`]                                                                          |               |

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   components:
     description: "Comma-separated list of components to be additionally installed"
     required: false
+  cargo-packages:
+    description: "Comma-separated list of Cargo packages to be additionally installed"
+    required: false
   cache:
     description: "Automatically configure Rust cache"
     required: false
@@ -134,7 +137,7 @@ runs:
       run: |
         if ! command -v rustup &> /dev/null ; then
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          
+
           # Resolve the correct CARGO_HOME path depending on OS
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             echo "${CARGO_HOME:-$USERPROFILE/.cargo}/bin" | sed 's|/|\\|g' >> $GITHUB_PATH
@@ -178,6 +181,13 @@ runs:
             rustup override set ${toolchain//*,/ }
           fi
         fi
+
+    - name: Install additional Cargo packages
+      if: inputs.cargo-packages != ''
+      env:
+        packages: ${{inputs.cargo-packages}}
+      shell: bash
+      run: cargo install ${packages//,/ }
 
     - id: versions
       name: Print installed versions


### PR DESCRIPTION
This PR adds a new input option to make installing cargo packages easier.

The inspiration for this was I planning to make my own `setup-rust` action after the https://github.com/dtolnay/rust-toolchain action doesn't respect a repository's toolchain file. I then found your action, which I was going to create a composite action around; but the only feature missing is to automatically install cargo packages. Hopefully this PR can be accepted and then I will not need to create a composite action around this. Thanks!