### PR TITLE
Fix: add rustup default check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -179,6 +179,10 @@ runs:
           # rustup toolchain install is the new explicit way
           # https://github.com/rust-lang/rustup/issues/3635#issuecomment-2343511297
           rustup show active-toolchain || rustup toolchain install
+          if ! rustup default &>/dev/null; then
+            TOOLCHAIN=$(rustup show active-toolchain 2>/dev/null | awk '{print $1}' | sed 's/-.*//')
+            [[ -n "$TOOLCHAIN" ]] && rustup default "$TOOLCHAIN" || rustup default stable
+          fi
           if [[ -n $components ]]; then
             rustup component add ${components//,/ }
           fi


### PR DESCRIPTION
The toolchain installation via the rust-toolchain/rust-toolchain.toml file, using the rust_src_dir flag, does not automatically set a global default in CI/CD. 
This PR adds a check that sets the default value in case it has not been correctly set after the toolchain installation.

Env details:

App + rust submodule (rust-toolchain.toml)
GitHub Actions runner
runs-on: ubuntu-24.04
container-image: quay.io/pypa/manylinux_2_28_x86_64

Fixes https://github.com/actions-rust-lang/setup-rust-toolchain/issues/74
