### PR TITLE
Bump Swatinem/rust-cache from 2.8.2 to 2.9.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -239,7 +239,7 @@ runs:
 
     - name: Setup Rust Caching
       if: inputs.cache == 'true'
-      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         workspaces: ${{ inputs.cache-workspaces || inputs.rust-src-dir }}
         cache-directories: ${{inputs.cache-directories}}


### PR DESCRIPTION
This PR bumps `Swatinem/rust-cache` from v2.8.2 to v2.9.1.

`rust-cache` v2.8.2 depends on Node.js 20, which reaches End of Life at the end of April 2026. GitHub Actions already emits the following deprecation warning on every workflow run:

> `Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`

Upgrading to v2.9.1 resolves this warning and ensures continued compatibility with GitHub Actions after the Node.js 24 enforcement date.
