### PR TITLE
chore: release rust-cache v2.9.2 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Update `Swatinem/rust-cache` to v2.9.2, which uses Node.js 24.
+
 ## [1.17.0] - 2026-06-25
 
 * Add new parameter `cache-targets` that is propagated to `Swatinem/rust-cache` as `cache-targets` (#84).


### PR DESCRIPTION
Document the Swatinem/rust-cache v2.9.2 update already present on main.

The released v1 tag still pins v2.9.1, which emits deprecated Node.js warnings. This changelog entry records the update for the next release so the floating v1 reference can pick it up.