### PR TITLE
Use CARGO_BUILD_WARNINGS for enforcing warning free compilations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
@@ -11,8 +11,9 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.2
+    rev: 0.38.0
     hooks:
       - id: check-dependabot
       - id: check-github-actions
-      - id: check-github-workflows
+      # Does not like the `null` value in the "rust" matrix in ci.yml
+      # - id: check-github-workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Use `CARGO_BUILD_WARNINGS` for enforcing warning free compilations (#98)
+    This is a new variable supported by cargo 1.97+ [and sets the `build.warnings` config](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/#cargo-support-for-denying-warnings).
+    It allows removing the `RUSTFLAGS="-D warnings"` default, which will improve compatibility with `target.*.rustflags` and `.cargo/config.toml` files.
+
+    This adds a new `build-warnings` input to configure the value for the `build.warnings` config.
+
 ## [1.17.0] - 2026-06-25
 
 * Add new parameter `cache-targets` that is propagated to `Swatinem/rust-cache` as `cache-targets` (#84).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `toolchain`              | Comma-separated list of Rustup toolchain specifier e.g. `stable`, `nightly`, `1.42.0`. The last version is the default.                                                            | stable        |
 | `target`                 | Additional target support to install e.g. `wasm32-unknown-unknown`                                                                                                                 |               |
+| `build-warnings`         | Sets the `build.warnings` config via the `CARGO_BUILD_WARNINGS` variable. (set to empty string to avoid overwriting existing flags)                                                | deny          |
 | `components`             | Comma-separated string of additional components to install e.g. `clippy, rustfmt`                                                                                                  |               |
 | `cache`                  | Automatically configure Rust cache (using [`Swatinem/rust-cache`])                                                                                                                 | true          |
 | `cache-directories`      | Propagates the value to [`Swatinem/rust-cache`]                                                                                                                                    |               |
@@ -66,7 +67,7 @@ Afterward, the `components` and `target` specified via inputs are installed in a
 | `cache-save-if`          | Propagates the value to [`Swatinem/rust-cache`] as `save-if`                                                                                                                       | true          |
 | `cache-targets`          | Propagates the value to [`Swatinem/rust-cache`] as `cache-targets`                                                                                                                 | true          |
 | `matcher`                | Enable problem matcher to surface build messages and formatting issues                                                                                                             | true          |
-| `rustflags`              | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                                                                             | "-D warnings" |
+| `rustflags`              | Set the value of `RUSTFLAGS` (set to empty string to avoid overwriting existing flags)                                                                                             | ""            |
 | `override`               | Setup the last installed toolchain as the default via `rustup override`                                                                                                            | true          |
 | `rust-src-dir`           | Path from root directory to directory with the Rust source directory (if its not in the root of the repository). Sets a default value for `cache-workspaces` that enables caching. |               |
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   target:
     description: "Target triple to install for this toolchain"
     required: false
+  build-warnings:
+    description: "Sets the build.warnings config via the CARGO_BUILD_WARNINGS variable."
+    required: false
+    default: "deny"
   components:
     description: "Comma-separated list of components to be additionally installed"
     required: false
@@ -72,7 +76,7 @@ inputs:
   rustflags:
     description: "set RUSTFLAGS environment variable, set to empty string to avoid overwriting build.rustflags"
     required: false
-    default: "-D warnings"
+    default: ""
   override:
     description: "Setup the last installed toolchain as the default via `rustup override`"
     required: false
@@ -124,6 +128,7 @@ runs:
     - name: Setting Environment Variables
       env:
         _srt_NEW_RUSTFLAGS: ${{inputs.rustflags}}
+        _srt_CARGO_BUILD_WARNINGS: ${{inputs.build-warnings}}
       shell: bash
       run: |
         if [[ ! -v CARGO_INCREMENTAL ]]; then
@@ -140,6 +145,9 @@ runs:
         fi
         if [[ ( ! -v RUSTFLAGS ) && $_srt_NEW_RUSTFLAGS != "" ]]; then
           echo "RUSTFLAGS=$_srt_NEW_RUSTFLAGS" >> $GITHUB_ENV
+        fi
+        if [[ ( ! -v CARGO_BUILD_WARNINGS ) && $_srt_CARGO_BUILD_WARNINGS != "" ]]; then
+          echo "CARGO_BUILD_WARNINGS=$_srt_CARGO_BUILD_WARNINGS" >> $GITHUB_ENV
         fi
         # Enable faster sparse index on nightly
         # The value is ignored on stable and causes no problems


### PR DESCRIPTION
This is a new variable supported by cargo 1.97+ and sets the build.warnings config. It allows removing the RUSTFLAGS="-D warnings" default, which will improve compatibility with target.*.rustflags and .cargo/config.toml files.

This adds a new build-warnings input to configure the value for the build.warnings config.

Closes #98